### PR TITLE
Added submodule to avoid author and acknoledgement doublons

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = files/pyplot-perso
 	url = git@github.com:simongravelle/pyplot-perso.git
 	branch = LAMMPS-livecom
+[submodule "dependencies/.github"]
+	path = dependencies/.github
+	url = git@github.com:lammpstutorials/.github.git

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -1,0 +1,29 @@
+# A Set of Tutorials for the LAMMPS Simulation Package
+
+This article introduces a suite of tutorials designed to make learning LAMMPS
+more accessible to new users.
+
+## Tutorials
+
+- Tutorial 1: Lennard-Jones ﬂuid
+- Tutorial 2: Pulling on a carbon nanotube
+- Tutorial 3: Polymer in water
+- Tutorial 4: Nanosheared electrolyte
+- Tutorial 5: Reactive silicon dioxide
+- Tutorial 6: Water adsorption in silica
+- Tutorial 7: Free energy calculation
+- Tutorial 8: ?
+
+## Files
+
+All the files corresponding to the tutorials can be found in the [files/](files/)
+folder. The Python scripts used to generate the plots are also provided.
+
+## Link
+
+Access the pdf from [this link](lammps-tutorials.pdf), or clone this repository
+and compile the tex file yourself by typing in a terminal:
+
+```
+make
+```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+<!--
+WARNING: DO NOT MODIFY DIRECTLY THE README.md!
+This README.md file was assembled using the sed command from the files listed in
+"files.txt". See the script in "generateREADME.sh". To modify the content of 
+the  README.md, modify the files listed in "files.txt", or add a new file to the
+list in "files.txt".
+-->
+
+
 # A Set of Tutorials for the LAMMPS Simulation Package
 
 This article introduces a suite of tutorials designed to make learning LAMMPS
@@ -16,26 +25,42 @@ more accessible to new users.
 
 ## Files
 
-All the files corresponding to the tutorials can be found in the [files/](files/) folder. The Python scripts
-used to generate the plots are also provided.
+All the files corresponding to the tutorials can be found in the [files/](files/)
+folder. The Python scripts used to generate the plots are also provided.
 
 ## Link
 
-Access the pdf from [this link](lammps-tutorials.pdf), or clone this repository and compile the tex file
-yourself by typing in a terminal:
+Access the pdf from [this link](lammps-tutorials.pdf), or clone this repository
+and compile the tex file yourself by typing in a terminal:
 
 ```
 make
 ```
 
-## List of Authors
 
-- Simon Gravelle, University Grenoble Alpes, CNRS, LIPhy, Grenoble, 38000, France
-- Jacob R. Gissinger, Stevens Institute of Technology, Hoboken, NJ 07030, USA
-- Axel Kohlmeyer, Institute for Computational Molecular Science, Temple University, Philadelphia, PA 19122, USA
+## Authors
 
-## Funding Information
+### Project creator
 
-S.G. acknowledges funding from the European Union's Horizon 2020 research and innovation
-programme under the Marie Skłodowska-Curie grant agreement N° 101065060$. A.K. acknowledges
-financial support by Sandia National Laboratories under POs 2149742 and 2407526.
+- [Simon Gravelle](https://github.com/simongravelle),
+  Univ. Grenoble Alpes, CNRS, LIPhy, 38000 Grenoble, France
+
+### Contributors
+
+- [Jacob R. Gissinger](https://www.stevens.edu/profile/jgissing),
+  Stevens Institute of Technology, Hoboken, NJ 07030, USA
+- [Axel Kohlmeyer](https://sites.google.com/site/akohlmey),
+  Institute for Computational Molecular Science, Temple University, Philadelphia,
+  PA 19122, USA
+
+
+
+## Acknowledgements
+
+- Simon Gravelle acknowledges funding from the European Union's Horizon 2020
+  research and innovation programme under the Marie Skłodowska-Curie grant
+  agreement No 101065060$.
+- Axel Kohlmeyer acknowledges financial support by Sandia National Laboratories
+  under POs 2149742 and 2407526.
+
+

--- a/files.txt
+++ b/files.txt
@@ -1,0 +1,4 @@
+./dependencies/.github/COMMENT.md
+DESCRIPTION.md
+./dependencies/.github/AUTHORS.md
+./dependencies/.github/ACKNOWLEDGEMENTS.md

--- a/generateREADME.sh
+++ b/generateREADME.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./dependencies/.github/generateREADME.sh


### PR DESCRIPTION
The AUTHORS.md and ACKNOLEDGEMENT.md files are read from the .github folder. This way, there is no duplicate of the same information between all the repositories. 

- .github was added as a submodule
- README.md is generated from sub-files