### PR TITLE
LAMMPS-GUI related updates

### DIFF
--- a/journal-article.bib
+++ b/journal-article.bib
@@ -692,7 +692,7 @@ Unique-ID = {{ISI:000272791800012}},
 
 @misc{lammps_run_docs,
   title = {{Run LAMMPS} Online Documentation for latest stable version},
-  howpublished = {\url{https://docs.lammps.org/Run_head.html}},
+  howpublished = {\url{https://docs.lammps.org/stable/Run_head.html}},
   note = {Accessed: 2024-12-14}
 }
 

--- a/journal-article.bib
+++ b/journal-article.bib
@@ -696,6 +696,12 @@ Unique-ID = {{ISI:000272791800012}},
   note = {Accessed: 2024-12-14}
 }
 
+@misc{lammps_github_release,
+  title = {{LAMMPS} releases page on {GitHub}},
+  howpublished = {\url{https://github.com/lammps/lammps/releases}},
+  note = {Accessed: 2024-12-26}
+}
+
 @article{typelabel_paper,
   author =       {Gissinger, Jacob R. and Nikiforov, Ilia and Afshar,
                   Yaser and Waters, Brendon and Choi, Moon-ki and Karls,

--- a/lammps-tutorials.tex
+++ b/lammps-tutorials.tex
@@ -324,7 +324,7 @@ tutorials, but other console or graphical text editors, such as GNU nano,
 vi/vim, Emacs, Notepad, Gedit, and Visual Studio Code, can also be
 used.  LAMMPS can be executed either directly from
 \lammpsgui{} (\hyperref[using-lammps-gui-label]{Appendix~\ref{using-lammps-gui-label}})
-or from the command line (\hyperref[command-line-label]{Appendix~\ref{command-line-label}}),
+or from the command-line (\hyperref[command-line-label]{Appendix~\ref{command-line-label}}),
 the latter of which requires some familiarity with executing commands
 from a terminal or command-line prompt.
 
@@ -352,7 +352,7 @@ versions.  For Linux (x86\_64 CPU), macOS (BigSur or later), and Windows
 (10 and 11) you can download a precompiled LAMMPS package from the
 LAMMPS release page on GitHub~\cite{lammps_github_release}.
 Select a package with `GUI' in the file name, which includes both,
-\lammpsgui{} and a LAMMPS command line executable.  These precompiled
+\lammpsgui{} and a LAMMPS command-line executable.  These precompiled
 packages are designed to be portable, and therefore omit support for
 parallel execution with MPI.  Instructions for installing \lammpsgui{}
 and using its most relevant features for the tutorials are provided in
@@ -374,11 +374,6 @@ Pandas/Matplotlib~\cite{van1995python,hunter2007Matplotlib}, XmGrace,
 Gnuplot, Microsoft Excel, and LibreOffice Calc.  For visualization,
 suitable external tools include VMD~\cite{vmd_home,humphrey1996vmd}
 and OVITO~\cite{ovito_home,ovito_paper}.
-
-% \hyperref[command-line-label]{Appendix~\ref{command-line-label}} has instructions
-% for running LAMMPS from the command line.
-% SG: I placed a reference of Appendix B before, so I dont think that sentence is
-% necessary here.
 
 \subsection{About \lammpsgui{}}
 
@@ -848,7 +843,7 @@ the trajectories of the atoms, let us use the \lmpcmd{dump image} command to
 create snapshot images during the simulation.  We have already explored
 the \guicmd{Image Viewer} window.  Open it again and adjust the
 visualization to your liking using the available buttons.  Now you can
-copy the command line used to create this visualization to the clipboard
+copy the commands used to create this visualization to the clipboard
 by either using the \guicmd{Ctrl-D} keyboard shortcut or selecting
 \guicmd{Copy dump image command} from the \guicmd{File} menu.  This text
 can be pasted into the into the \lmpcmd{Visualization} section of
@@ -4346,7 +4341,7 @@ menu under ``Science''.  Additionally, the ``.lmp'' file extension will be
 registered to launch \lammpsgui{} when opening a file with this
 extension in the desktop's file manager.
 
-You can also launch \lammpsgui{} from the command line using the following command:
+You can also launch \lammpsgui{} from the command-line using the following command:
 \begin{lstlisting}[language=tcl]
 flatpak run org.lammps.lammps-gui
 \end{lstlisting}
@@ -4386,11 +4381,11 @@ After installation, a new entry should appear in the Start menu.
 Additionally, the ``.lmp'' file extension should be registered with
 Windows File Explorer to open \lammpsgui{} when opening a file with the
 ``.lmp`` extension.  The ``lammps-gui'' and ``lmp'' commands should also
-be available in the command line.
+be available in the command-line.
 
 \subsection{Opening, Editing, and Saving Files}
 
-\lammpsgui{} can be launched from the command line, as explained above, where you
+\lammpsgui{} can be launched from the command-line, as explained above, where you
 can either launch it without arguments or provide one file name as an argument.  All
 other arguments will be ignored.  For example:
 \begin{lstlisting}[language=tcl]
@@ -4415,7 +4410,7 @@ commands, there will be completion pop-ups for their
 keywords or when a filename is expected, in which case,
 the pop-up will list files in the current folder.
 
-As soon as \lammpsgui{} recognizes a command line, it applies syntax
+As soon as \lammpsgui{} recognizes a command, it applies syntax
 highlighting according to built-in categories.  This can help
 detect typos, since those may cause \lammpsgui{} not to
 recognize the syntax and thus not apply or partially apply
@@ -4515,21 +4510,20 @@ made to the \flecmd{.lmp} file upon closing \lammpsgui{}.
 \end{itemize}
 See Ref.\,\citenum{lammps_gui_docs} for a full list of options.
 
-\section{Running LAMMPS on the Command Line without the GUI}
+\section{Running LAMMPS on the Command-Line without the GUI}
 \label{command-line-label}
 
-LAMMPS can also be executed from the command line on Linux, macOS, and
+LAMMPS can also be executed from the command-line on Linux, macOS, and
 Windows without using the GUI.  This is the more common way to run LAMMPS.
-Both, the \lammpsgui{} program and the LAMMPS command line executable
-utilize the same LAMMPS library and thus no changes to the input file should
-be required.
+Both, the \lammpsgui{} program and the LAMMPS command-line executable
+utilize the same LAMMPS library and thus no changes to the input file are required.
 
-First open a terminal or command line prompt window and navigate to the
-directory containing the \flecmd{input.lmp} file. Then execute:
+First, open a terminal or command-line prompt window and navigate to the
+directory containing the \flecmd{input.lmp} file.  Then execute:
 \begin{lstlisting}[language=tcl]
 lmp -in input.lmp
 \end{lstlisting}
-where \flecmd{lmp} is the command line LAMMPS command.
+where \flecmd{lmp} is the command-line LAMMPS command.
 
 For parallel execution with 4 processors (via OpenMP threads where supported
 by the OPENMP package), use:
@@ -4538,11 +4532,11 @@ lmp -in input.lmp -pk omp 4 -sf omp
 \end{lstlisting}
 
 \begin{note}
-  Running in parallel via MPI requires a correspondingly compiled LAMMPS
-  package and is not compatible with the GUI.  On supercomputers or HPC
-  clusters, pre-compiled LAMMPS executables are often provided by the
-  user support staff.  Please consult the corresponding documentation of
-  the facility or contact its user support for more information.
+  Running in parallel via MPI requires a specially compiled LAMMPS
+  package and is not supported by the GUI.  On supercomputers or HPC
+  clusters, pre-compiled LAMMPS executables are typically provided
+  by the facility's user support team.  For more information, please
+  refer to the facility's documentation or contact its user support staff.
 \end{note}
 
 See Ref.\,\citenum{lammps_run_docs} for a complete description on how to

--- a/lammps-tutorials.tex
+++ b/lammps-tutorials.tex
@@ -4313,71 +4313,80 @@ use the ``Command'' key (\cmd) in place of the
 
 \subsection{Installation}
 
-Precompiled versions of LAMMPS--GUI are available for Linux, {macOS}, and
-Windows.  The Linux version is provided in two formats: as compressed tar
-archive (.tar.gz) and as a Flatpak bundle~\cite{flatpak_home}.  The {macOS}
-version is distributed as a .dmg installer image, while the Windows version comes
-as an executable installer package.
+Precompiled versions of \lammpsgui{} are available for Linux, {macOS},
+and Windows on the LAMMPS GitHub Release
+page~\cite{lammps_github_release}.  The Linux version is provided in two
+formats: as compressed tar archive (.tar.gz) and as a Flatpak
+bundle~\cite{flatpak_home}.  The {macOS} version is distributed as a
+.dmg installer image, while the Windows version comes as an executable
+installer package.
 
-\subsubsection{Installing the Linux .tar.gz variant}
+\subsubsection{Installing the Linux .tar.gz Package}
 
-Download the archive (e.g.,~LAMMPS-Linux-x86\_64-GUI-29Aug2024\_update1.tar.gz)
+Download the archive (e.g.,~LAMMPS-Linux-x86\_64-GUI-29Aug2024\_update2.tar.gz)
 and unpack it.  This will create a folder named LAMMPS\_GUI containing the
 included commands, which can be launched directly using ``./lammps-gui'' or
 ``./lmp'', for example.  Adding this folder to the PATH environment
 variable will make these commands accessible from everywhere, without the
 need for the ``./'' prefix.
 
-\subsubsection{Installing Linux .flatpak variant}
+\subsubsection{Installing the Linux Flatpak Bundle}
 
-Download the bundle file and then install it using the following command:
-\begin{lstlisting}
+You have to have Flatpak support installed on Linux machine to be able
+to use the Flatpak bundle.  Download the bundle file
+(e.g.,~LAMMPS-Linux-x86\_64-GUI-29Aug2024\_update2.flatpak) and then
+install it using the following command:
+\begin{lstlisting}[language=tcl]
 flatpak install --user \
-    LAMMPS-Linux-x86_64-GUI-29Aug2024_update1.flatpak
+    LAMMPS-Linux-x86_64-GUI-29Aug2024_update2.flatpak
 \end{lstlisting}
-This will integrate LAMMPS--GUI into your desktop environment
+This will integrate \lammpsgui{} into your desktop environment
 (e.g.,~GNOME, KDE, XFCE) where it should appear in the ``Applications''
 menu under ``Science''.  Additionally, the ``.lmp'' file extension will be
-registered to launch LAMMPS--GUI when opening a file with this
-extension in the desktop's file manager.  You can then
-launch LAMMPS--GUI from the command line using the following command:
-\begin{lstlisting}
+registered to launch \lammpsgui{} when opening a file with this
+extension in the desktop's file manager.
+
+You can also launch \lammpsgui{} from the command line using the following command:
+\begin{lstlisting}[language=tcl]
 flatpak run org.lammps.lammps-gui
 \end{lstlisting}
-Similarly, for the LAMMPS command-line version, use:
-\begin{lstlisting}
+Similarly, for launching the LAMMPS command-line executable, use:
+\begin{lstlisting}[language=tcl]
 flatpak run --command=lmp org.lammps.lammps-gui -in in.lmp
 \end{lstlisting}
 
-\subsubsection{Installing the macOS .dmg package}
+\subsubsection{Installing the macOS Application Bundle}
 
-After downloading the LAMMPS-macOS-multiarch-GUI-29Aug2024\_update1.dmg file,
-double-click on it and then drag the LAMMPS\_GUI app bundle
-into the Applications folder shown in the dialog that opens.  To
-enable command-line access, follow the instructions in the README.txt
-file.
+After downloading the macOS app bundle image file
+(e.g.,~LAMMPS-macOS-multiarch-GUI-29Aug2024\_update2.dmg), double-click
+on it.  In the dialog that opens drag the LAMMPS\_GUI app bundle into
+the Applications folder.  To enable command-line access, follow the
+instructions in the README.txt file.  These macOS app-bundles contain
+native executables for both, Intel and Apple CPUs.
 
 After installation, you can launch LAMMPS\_GUI from the Applications
-folder.  Additionally, you can drag an input file onto the app or open files with the
-``.lmp'' extension.  Note that the LAMMPS--GUI bundle is currently not
-cryptographically signed, so macOS may initially prevent it from launching.
-If this happens, you can adjust the settings in the ``Security \& Privacy" system
-preferences dialog to allow access.
+folder.  Additionally, you can drag an input file onto the app or open
+files with the ``.lmp'' extension.  Note that the \lammpsgui{} app bundle is
+currently not cryptographically signed, so macOS may initially prevent
+it from launching.  If this happens, you need to adjust the settings in
+the ``Security \& Privacy" system preferences dialog to allow access.
 
-\subsubsection{Installing the Windows .exe package}
+\subsubsection{Installing the Windows package}
 
-Download the LAMMPS-Win10-64bit-GUI-29Aug2024\_update.exe installer.
-Windows may warn you that the file is from an unknown developer
-and was downloaded from the internet.  This happens because neither the
-installer nor the LAMMPS--GUI application (or any other applications inside)
-have been cryptographically signed.  You will need to choose to keep the file,
-and when launching the installer again, confirm that you want to run it despite the warning.
+Download the \lammpsgui{} installer for Windows
+(e.g.,~LAMMPS-Win10-64bit-GUI-29Aug2024\_update2.exe).  Windows may warn
+you that the file is from an unknown developer and was downloaded from
+the internet.  This happens because neither the installer nor the
+\lammpsgui{} application (or any other included applications) have been
+cryptographically signed.  You will need to choose to keep the file, and
+when launching the installer, confirm that you want to run it despite
+the warning.
 
-After installation, a new entry should appear in the Start menu.  Additionally,
-the ``.lmp'' file extension should be registered with  Windows File
-Explorer to open LAMMPS--GUI when opening a file with that
-extension.  The ``lammps-gui'' and ``lmp'' commands should also be available
-in the command line, either in a Command Prompt or Terminal window.
+After installation, a new entry should appear in the Start menu.
+Additionally, the ``.lmp'' file extension should be registered with
+Windows File Explorer to open \lammpsgui{} when opening a file with the
+``.lmp`` extension.  The ``lammps-gui'' and ``lmp'' commands should also
+be available in the command line.
 
 \subsection{Opening, Editing, and Saving Files}
 

--- a/lammps-tutorials.tex
+++ b/lammps-tutorials.tex
@@ -4515,27 +4515,38 @@ made to the \flecmd{.lmp} file upon closing \lammpsgui{}.
 \end{itemize}
 See Ref.\,\citenum{lammps_gui_docs} for a full list of options.
 
-\section{Running LAMMPS via Command Line}
+\section{Running LAMMPS on the Command Line without the GUI}
 \label{command-line-label}
 
-LAMMPS can be executed from the command line on Linux, macOS,
-as well as Windows.  On Linux/macOS, first navigate to the directory containing
-the \flecmd{input.lmp} file and execute:
-\begin{lstlisting}
+LAMMPS can also be executed from the command line on Linux, macOS, and
+Windows without using the GUI.  This is the more common way to run LAMMPS.
+Both, the \lammpsgui{} program and the LAMMPS command line executable
+utilize the same LAMMPS library and thus no changes to the input file should
+be required.
+
+First open a terminal or command line prompt window and navigate to the
+directory containing the \flecmd{input.lmp} file. Then execute:
+\begin{lstlisting}[language=tcl]
 lmp -in input.lmp
 \end{lstlisting}
-where \flecmd{lmp} is the LAMMPS executable.
-For parallel execution on 4 processors, use:
-\begin{lstlisting}[language=bash]
-mpirun -np 4 lmp -in input.lmp
+where \flecmd{lmp} is the command line LAMMPS command.
+
+For parallel execution with 4 processors (via OpenMP threads where supported
+by the OPENMP package), use:
+\begin{lstlisting}[language=tcl]
+lmp -in input.lmp -pk omp 4 -sf omp
 \end{lstlisting}
-On Windows, run the following command via Command Prompt or PowerShell:
-\begin{lstlisting}
-lmp.exe -in input.lmp
-\end{lstlisting}
-where \flecmd{lmp.exe} is the Windows executable version of LAMMPS.  See
-Ref.\,\citenum{lammps_run_docs} for a complete description on how to run
-LAMMPS.
+
+\begin{note}
+  Running in parallel via MPI requires a correspondingly compiled LAMMPS
+  package and is not compatible with the GUI.  On supercomputers or HPC
+  clusters, pre-compiled LAMMPS executables are often provided by the
+  user support staff.  Please consult the corresponding documentation of
+  the facility or contact its user support for more information.
+\end{note}
+
+See Ref.\,\citenum{lammps_run_docs} for a complete description on how to
+run LAMMPS.
 
 \end{appendices}
 

--- a/lammps-tutorials.tex
+++ b/lammps-tutorials.tex
@@ -102,6 +102,10 @@
 \newcommand{\guicmd}[1]{\textcolor{command}{\texttt{«#1»}}} % LAMMPS-GUI commands in French quotation monopace
 \newcommand{\dwlcmd}[1]{\textcolor{download}{\texttt{#1}}} % downloadable files in monopace blue
 
+% The DisableLigatures command above turns the longer dash (--) into two dashes.
+% This works around it by using \lammpsgui{} instead and making the longer dash explicit.
+\newcommand{\lammpsgui}{\textsf{LAMMPS\textendash GUI}}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% IMPORTANT USER CONFIGURATION
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -181,11 +185,11 @@
   tutorials address more advanced molecular simulation techniques,
   specifically the use of a reactive force field, grand canonical Monte Carlo,
   enhanced sampling, and REACTER protocol.
-  In addition, we introduce LAMMPS--GUI, an enhanced graphical text
+  In addition, we introduce \lammpsgui{}, an enhanced graphical text
   editor with syntax highlighting, command completion, context help,
   plus built--in visualization and plotting facilities, and the ability
   to run LAMMPS directly on the input file while tracking its progress.
-  LAMMPS--GUI is used as the primary tool in the tutorials to edit
+  \lammpsgui{} is used as the primary tool in the tutorials to edit
   inputs, run LAMMPS, extract data, and visualize the simulated systems.
 \end{abstract}
 
@@ -314,12 +318,12 @@ of water molecules is tracked over time~\cite{gissinger2020reacter}.
 
 This set of tutorials assumes no prior knowledge of the LAMMPS software
 itself.  To complete the tutorials, a text editor and a suitable LAMMPS
-executable are required.  We use LAMMPS--GUI~\cite{lammps_gui_docs}
+executable are required.  We use \lammpsgui{}~\cite{lammps_gui_docs}
 here, as it offers features that make it particularly convenient for
 tutorials, but other console or graphical text editors, such as GNU nano,
 vi/vim, Emacs, Notepad, Gedit, and Visual Studio Code, can also be
 used.  LAMMPS can be executed either directly from
-LAMMPS--GUI (\hyperref[using-lammps-gui-label]{Appendix~\ref{using-lammps-gui-label}})
+\lammpsgui{} (\hyperref[using-lammps-gui-label]{Appendix~\ref{using-lammps-gui-label}})
 or from the command line (\hyperref[command-line-label]{Appendix~\ref{command-line-label}}),
 the latter of which requires some familiarity with executing commands
 from a terminal or command-line prompt.
@@ -341,18 +345,17 @@ and molecular simulations~\cite{sklogwiki_main_page}.
 
 \subsection{Software/system requirements}
 
-The LAMMPS release version 29Aug2024~\cite{lammps_code} and the
-matching LAMMPS--GUI software version 1.6.11 are required to follow the
-tutorials, as they include features that were first introduced in these versions.
-For Linux (x86\_64 CPU), macOS (BigSur or later), and Windows (10
-and 11) you can download a precompiled LAMMPS package from the LAMMPS
-release page on GitHub
-(\href{https://github.com/lammps/lammps/releases}{github.com/lammps/lammps/releases}).
-Select a package with `GUI' in the file name, which includes
-both LAMMPS--GUI and a LAMMPS console executable.  These
-precompiled packages are designed to be portable, and therefore omit support for
-parallel execution with MPI.  Instructions for installing LAMMPS--GUI and
-using its most relevant features for the tutorials are provided in 
+The LAMMPS release version 29Aug2024~\cite{lammps_code} and the matching
+\lammpsgui{} software version 1.6.11 are required to follow the
+tutorials, as they include features that were first introduced in these
+versions.  For Linux (x86\_64 CPU), macOS (BigSur or later), and Windows
+(10 and 11) you can download a precompiled LAMMPS package from the
+LAMMPS release page on GitHub~\cite{lammps_github_release}.
+Select a package with `GUI' in the file name, which includes both,
+\lammpsgui{} and a LAMMPS command line executable.  These precompiled
+packages are designed to be portable, and therefore omit support for
+parallel execution with MPI.  Instructions for installing \lammpsgui{}
+and using its most relevant features for the tutorials are provided in
 \hyperref[using-lammps-gui-label]{Appendix~\ref{using-lammps-gui-label}}.
 
 LAMMPS versions are generally backward compatible, meaning that old
@@ -360,12 +363,12 @@ input files typically work with newer versions of LAMMPS.  However,
 forward compatibility is not as strong, so
 newer input files may not work with older versions.  As a result, it is
 usually possible to follow this tutorial with more recent releases of
-LAMMPS--GUI and LAMMPS, though older versions may require some minor adjustments.
+\lammpsgui{} and LAMMPS, though older versions may require some minor adjustments.
 These tutorials will be periodically updated to ensure compatibility
 and take advantage of new features in the latest stable version of LAMMPS.
 
 For some tutorials, external tools are required for plotting and
-visualization, as the corresponding functionality in LAMMPS--GUI is
+visualization, as the corresponding functionality in \lammpsgui{} is
 limited.  Suitable external tools for plotting include Python with
 Pandas/Matplotlib~\cite{van1995python,hunter2007Matplotlib}, XmGrace,
 Gnuplot, Microsoft Excel, and LibreOffice Calc.  For visualization,
@@ -377,9 +380,9 @@ and OVITO~\cite{ovito_home,ovito_paper}.
 % SG: I placed a reference of Appendix B before, so I dont think that sentence is
 % necessary here.
 
-\subsection{About LAMMPS--GUI}
+\subsection{About \lammpsgui{}}
 
-LAMMPS--GUI is a graphical text editor, enhanced for editing LAMMPS input
+\lammpsgui{} is a graphical text editor, enhanced for editing LAMMPS input
 files and linked to the LAMMPS library, allowing it to run LAMMPS
 directly.  The text editor functions similarly to other graphical editors,
 such as Notepad or Gedit, but offers the following enhancements specifically for LAMMPS:
@@ -403,8 +406,8 @@ such as Notepad or Gedit, but offers the following enhancements specifically for
   \item Use of wizard dialogs to set up tutorials
 \end{itemize}
 \hyperref[using-lammps-gui-label]{Appendix~\ref{using-lammps-gui-label}}
-contains basic instructions for installation and using LAMMPS--GUI with
-the tutorials presented here.  A complete description of all LAMMPS--GUI
+contains basic instructions for installation and using \lammpsgui{} with
+the tutorials presented here.  A complete description of all \lammpsgui{}
 features can be found in the LAMMPS manual~\cite{lammps_gui_docs}.
 
 \section{Content and links}
@@ -416,11 +419,11 @@ and inputs required to follow the tutorials are available from a
 dedicated GitHub organization account,
 \href{https://github.com/lammpstutorials}{github.com/lammpstutorials}.
 These files can also be downloaded by clicking \guicmd{Start LAMMPS Tutorial X}
-(where \texttt{X} = 1...8) from the \guicmd{Tutorials} menu of LAMMPS--GUI.
+(where \texttt{X} = 1...8) from the \guicmd{Tutorials} menu of \lammpsgui{}.
 
 In the following, all LAMMPS input or console commands are formatted
 with a \lmpcmd{colored background}.  Keyboard shortcuts and
-file names are formatted in \flecmd{monospace}, and LAMMPS--GUI options and menus
+file names are formatted in \flecmd{monospace}, and \lammpsgui{} options and menus
 are displayed in \guicmd{quoted monospace}.
 % S.G.: I removed "folder names" because all folders will eventually be removed (TO CONTROL BEFORE SUBMITTING)
 % S.G.: I removed "Section titles" as well because it seems to be using a different style
@@ -451,10 +454,10 @@ To run a simulation using LAMMPS, you need to write an input script containing
 a series of commands for LAMMPS to execute.  For clarity, the
 input scripts for this tutorial will be divided into five categories,
 which will be filled out step by step.  To set up this tutorial, select
-\guicmd{Start LAMMPS Tutorial 1} from the \guicmd{Tutorials} menu of LAMMPS--GUI, and
+\guicmd{Start LAMMPS Tutorial 1} from the \guicmd{Tutorials} menu of \lammpsgui{}, and
 follow the instructions.  This will select (or create, if needed) a folder,
 place the initial input file \flecmd{initial.lmp} in it, and
-open the file in the LAMMPS--GUI editor.  The editor should display the
+open the file in the \lammpsgui{} editor.  The editor should display the
 following content:
 \begin{lstlisting}
 # PART A - ENERGY MINIMIZATION
@@ -465,7 +468,7 @@ following content:
 # 5) Run
 \end{lstlisting}
 Everything that appears after a hash symbol ($\#$) is a comment
-and ignored by LAMMPS.  LAMMPS--GUI will color such comments in red.
+and ignored by LAMMPS.  \lammpsgui{} will color such comments in red.
 These five categories are not required in every input script and do not
 necessarily need to be in that exact order.  For instance, the \lmpcmd{Settings}
 and the \lmpcmd{Visualization} categories could be inverted, or
@@ -525,7 +528,7 @@ to avoid confusion when sharing input files with other LAMMPS users.
 \begin{figure}
 \centering
 \includegraphics[width=\linewidth]{GUI-1.png}
-\caption{A screenshot of the LAMMPS--GUI \guicmd{Editor} window during
+\caption{A screenshot of the \lammpsgui{} \guicmd{Editor} window during
   \hyperref[lennard-jones-label]{Tutorial 1}.  The coloring of the text
   is based on the syntax for LAMMPS input files.  The pop-up menu is the
   context menu for right-clicking on the \lmpcmd{atom\_style} line.}
@@ -533,7 +536,7 @@ to avoid confusion when sharing input files with other LAMMPS users.
 \end{figure}
 
 Each LAMMPS command is accompanied by extensive online documentation
-that details the different options for that command.  From the LAMMPS--GUI
+that details the different options for that command.  From the \lammpsgui{}
 editor buffer, you can access the documentation by
 right-clicking on a line containing a command (e.g.,~\lmpcmd{units lj}) and
 selecting \guicmd{View documentation for (\dots)}\,.  This action will
@@ -623,7 +626,7 @@ $\sigma_{12} = \sqrt{1.0 \times 3.0} = 1.732$.
 \centering
 \includegraphics[width=0.55\linewidth]{LJ}
 \caption{The binary mixture simulated in \hyperref[lennard-jones-label]{Tutorial 1}.
-  This image was generated directly from the LAMMPS--GUI.  Atoms of
+  This image was generated directly from the \lammpsgui{}.  Atoms of
   type 1 are represented as small red spheres, atoms of type 2 as large
   green spheres, and the edges of the simulation box are represented as blue sticks.}
 \label{fig:LJ}
@@ -650,7 +653,7 @@ without actually running the simulation.  The \lmpcmd{post no} option disables
 the post-run summary and statistics output.
 
 You can now run LAMMPS.  The simulation should finish quickly, and with the default
-settings, LAMMPS--GUI will open two windows: one displaying the console
+settings, \lammpsgui{} will open two windows: one displaying the console
 output and another with a chart.  The \guicmd{Output} window will display information from
 the executed commands, including the total energy and pressure at step 0,
 as specified by the thermodynamic data request.  Since no actual simulation
@@ -688,9 +691,9 @@ energy. % SG: I don't think that its true, its rather the algorithm
 Note that, except for trivial systems, minimization algorithms will find a
 local minimum rather than the global minimum.
 
-Run the minimization and observe that LAMMPS--GUI captures the output
+Run the minimization and observe that \lammpsgui{} captures the output
 and update the chart in real time (see Fig.~\ref{fig:chart-log}).  This run executes quickly (depending
-on your computer's capabilities), but LAMMPS--GUI may fail to capture some
+on your computer's capabilities), but \lammpsgui{} may fail to capture some
 of the thermodynamic data.  In that
 case, use the \guicmd{Preferences} dialog to reduce the data update
 interval and switch to single-threaded, unaccelerated execution in the
@@ -701,7 +704,7 @@ fresh, resetting the system and re-executing the script from the beginning.
 \centering
 \includegraphics[width=0.49\linewidth]{chart-1}
 \includegraphics[width=0.497\linewidth]{output-1}
-\caption{\guicmd{Charts} (left) and \guicmd{Output} (right) windows of LAMMPS--GUI
+\caption{\guicmd{Charts} (left) and \guicmd{Output} (right) windows of \lammpsgui{}
   after performing the minimization simulation of \hyperref[lennard-jones-label]{Tutorial 1}.}
   % SG: TODO - retake the snapshot with the same data as the next figure
 \label{fig:chart-log}
@@ -943,7 +946,7 @@ minimization step, eliminating the need to repeat the system creation and minimi
 
 Run the \flecmd{improved.min.lmp} file using LAMMPS.  At the end of the simulation,
 a file called \flecmd{improved.min.data} is created.  You can view the contents
-of this file from the LAMMPS--GUI, by right-clicking on the file name in
+of this file from the \lammpsgui{}, by right-clicking on the file name in
 the editor and selecting the entry \guicmd{View file `improved.min.data'}.
 
 The created \flecmd{.data} file contains all the information necessary to
@@ -1160,7 +1163,7 @@ variables \lmpcmd{n1\_in} and \lmpcmd{n2\_in}, you can track the number
 of atoms in each region as a function of time
 (Fig.~\ref{fig:mixing}\,a).  To view their evolution, select the entries
 \guicmd{v\_n1\_in} or \guicmd{v\_n2\_in} in the \guicmd{Select data} drop-down
-menu in the \guicmd{Charts} window of LAMMPS--GUI.
+menu in the \guicmd{Charts} window of \lammpsgui{}.
 
 In addition, as the mixing progresses, the average coordination number
 between atoms of types 1 and 2 increases from about $0.01$ to $0.04$
@@ -1226,7 +1229,7 @@ second part, a reactive force field (called AIREBO
 \cite{stuart2000reactive}) is used, which allows chemical bonds to break under large strain.
 
 To set up this tutorial, select \guicmd{Start Tutorial 2} from the
-\guicmd{Tutorials} menu of LAMMPS--GUI and follow the instructions.  This will
+\guicmd{Tutorials} menu of \lammpsgui{} and follow the instructions.  This will
 select a folder, create one if necessary, and place several files into it.
 The initial input file, set up for a single-point energy
 calculation, will also be loaded into the editor under the name
@@ -1751,7 +1754,7 @@ A rectangular box of water is created and equilibrated at ambient temperature an
 pressure.  The SPC/Fw water model is used~\cite{wu2006flexible}, which is
 a flexible variant of the rigid SPC (simple point charge) model~\cite{berendsen1981interaction}.
 To set up this tutorial, select \guicmd{Start Tutorial 3} from the
-\guicmd{Tutorials} menu of LAMMPS--GUI and follow the instructions.
+\guicmd{Tutorials} menu of \lammpsgui{} and follow the instructions.
 The editor should display the following content corresponding to \flecmd{water.lmp}:
 \begin{lstlisting}
 units real
@@ -1915,7 +1918,7 @@ The binary file created by the \lmpcmdnote{write\_restart} command contains the
 complete state of the simulation, including atomic positions, velocities, and
 box dimensions (similar to \lmpcmdnote{write\_data}), but also the groups,
 the compute, or the \lmpcmdnote{atom\_style}.  Use the \guicmd{Inspect Restart}
-option of the LAMMPS--GUI to vizualize the content saved in \flecmd{water.restart}.
+option of the \lammpsgui{} to vizualize the content saved in \flecmd{water.restart}.
 \end{note}
 
 \begin{figure}
@@ -2186,7 +2189,7 @@ desired temperature and pressure.
 \paragraph{System generation}
 
 To set up this tutorial, select \guicmd{Start Tutorial 4} from the
-\guicmd{Tutorials} menu of LAMMPS--GUI and follow the instructions.
+\guicmd{Tutorials} menu of \lammpsgui{} and follow the instructions.
 The editor should display the following content corresponding to \flecmd{create.lmp}:
 \begin{lstlisting}
 boundary p p f
@@ -2783,7 +2786,7 @@ The first action we need to perform here is to relax the structure with ReaxFF,
 which we are gonna do using molecular dynamics.  As always, to make sure that the system
 equilibrates nicely, we will us track certain parameters over time.  To set up this
 tutorial, select \guicmd{Start Tutorial 5} from the
-\guicmd{Tutorials} menu of LAMMPS--GUI and follow the instructions.
+\guicmd{Tutorials} menu of \lammpsgui{} and follow the instructions.
 The editor should display the following content corresponding to \flecmd{relax.lmp}:
 \begin{lstlisting}
 units real
@@ -3152,7 +3155,7 @@ potential of water within a nanoporous SiO$_2$ structure.
 \subsubsection{Generation of the silica block}
 
 \noindent To begin this tutorial, select \guicmd{Start Tutorial 6} from the
-\guicmd{Tutorials} menu of LAMMPS--GUI and follow the instructions.
+\guicmd{Tutorials} menu of \lammpsgui{} and follow the instructions.
 The editor should display the following content corresponding to \flecmd{generate.lmp}:
 \begin{lstlisting}
 units metal
@@ -3597,7 +3600,7 @@ favorable area to explore.
 \paragraph{Basic LAMMPS parameters}
 
 To begin this tutorial, select \guicmd{Start Tutorial 7} from the
-\guicmd{Tutorials} menu of LAMMPS--GUI and follow the instructions.
+\guicmd{Tutorials} menu of \lammpsgui{} and follow the instructions.
 The editor should display the following content corresponding to \flecmd{free-energy.lmp}:
 \begin{lstlisting}
 variable sigma equal 3.405
@@ -3986,7 +3989,7 @@ protocol relies on the use of a \textit{classical} force field.
 \subsubsection{Creating the system}
 
 To begin this tutorial, select \guicmd{Start Tutorial 8} from the
-\guicmd{Tutorials} menu of LAMMPS--GUI and follow the instructions.
+\guicmd{Tutorials} menu of \lammpsgui{} and follow the instructions.
 The editor should display the following content corresponding to \flecmd{mixing.lmp}:
 \begin{lstlisting}
 units real
@@ -4273,7 +4276,7 @@ S.G. conceived and wrote the original online tutorials and underlying Sphinx doc
 for \href{https://lammpstutorials.github.io}{lammpstutorials.github.io}.
 J.G. is the principal author of \lmpcmd{fix bond/react} and \lmpcmd{type labels}
 support in LAMMPS.  He revised the tutorials to incorporate type labels and wrote Tutorial 8.
-A.K. developed the LAMMPS--GUI software and assisted in revising the
+A.K. developed the \lammpsgui{} software and assisted in revising the
 tutorials for use with it.  All authors participated in the revision and finalization
 of the manuscript.
 
@@ -4298,7 +4301,7 @@ POs~2149742 and 2407526.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \begin{appendices}
-\section{Using LAMMPS--GUI}
+\section{Using \lammpsgui{}}
 \label{using-lammps-gui-label}
 
 \begin{note}
@@ -4378,10 +4381,10 @@ in the command line, either in a Command Prompt or Terminal window.
 
 \subsection{Opening, Editing, and Saving Files}
 
-LAMMPS--GUI can be launched from the command line, as explained above, where you
+\lammpsgui{} can be launched from the command line, as explained above, where you
 can either launch it without arguments or provide one file name as an argument.  All
 other arguments will be ignored.  For example:
-\begin{lstlisting}
+\begin{lstlisting}[language=tcl]
 lammps-gui input.lmp
 \end{lstlisting}
 Files can also be opened from the ``File'' menu.  You can select a
@@ -4403,9 +4406,9 @@ commands, there will be completion pop-ups for their
 keywords or when a filename is expected, in which case,
 the pop-up will list files in the current folder.
 
-As soon as LAMMPS--GUI recognizes a command line, it applies syntax
+As soon as \lammpsgui{} recognizes a command line, it applies syntax
 highlighting according to built-in categories.  This can help
-detect typos, since those may cause LAMMPS--GUI not to
+detect typos, since those may cause \lammpsgui{} not to
 recognize the syntax and thus not apply or partially apply
 the syntax highlighting.  When you press the \texttt{Tab} key, the line will be
 reformatted.  Consistent formatting can improve the readability of
@@ -4418,7 +4421,7 @@ buffer can be saved by selecting ``Save'' or ``Save As...'' from the
 of the status bar, or use the \texttt{Ctrl--S} keyboard shortcut.
 
 \begin{note}
-When LAMMPS--GUI opens a file, it will \emph{switch} the working directory
+When \lammpsgui{} opens a file, it will \emph{switch} the working directory
 to the folder that contains the input file.  The same happens when saving to
 a different folder than the current working directory.  The current working
 directory can be seen in the status bar at the bottom right.  This is important
@@ -4431,7 +4434,7 @@ which are typically expected to be in the same folder as the input file.
 %the ``Save'' or ``Save As'' entry in the ``File'' menu, using the
 %\texttt{Ctrl--S} keyboard shortcut or by clicking on the ``Save'' icon
 %at the bottom left of the \textit{Editor} window status bar.  For
-%running LAMMPS in LAMMPS--GUI it is not required to save the buffer.
+%running LAMMPS in \lammpsgui{} it is not required to save the buffer.
 %The current contents of the buffer will be passed on to LAMMPS.
 %However, if you prefer to have your editor buffer automatically saved
 %before launching a run or exiting the LAMMPS-GUI, there is a setting for this
@@ -4442,7 +4445,7 @@ which are typically expected to be in the same folder as the input file.
 % mention no log file -> Output window -> Save to file
 % SG: the "no log file" is already specified in the "The Output Window" subsection, so may be unecessary?
 
-From within the LAMMPS--GUI main window, LAMMPS can be started either from
+From within the \lammpsgui{} main window, LAMMPS can be started either from
 the \guicmd{Run} menu by selecting the \guicmd{Run LAMMPS from Editor Buffer} entry,
 using the keyboard shortcut Ctrl-Enter (Command-Enter on macOS), or by clicking the
 green \guicmd{Run} button in the status bar.  While LAMMPS is running, a message on
@@ -4485,13 +4488,13 @@ by clicking the \guicmd{lens} button located next to the data drop-down menu.
 \subsection{Preferences}
 
 The Preferences dialog allows customization of the behavior and appearance of
-LAMMPS--GUI.  Among other options:
+\lammpsgui{}.  Among other options:
 \begin{itemize}
 \item In the \guicmd{General Settings} tab, the \guicmd{Data update interval} setting
 allows you to define the time interval, in milliseconds, between data updates during
 a LAMMPS run.  By default, the data for the \guicmd{Charts} and \guicmd{Output}
 windows is updated every 10 milliseconds.  Set this to 100 milliseconds or more
-if LAMMPS--GUI consumes too many resources during a run.  The \guicmd{Charts update interval}
+if \lammpsgui{} consumes too many resources during a run.  The \guicmd{Charts update interval}
 controls the time interval between redrawing the plots in the \guicmd{Charts} window, in milliseconds.
 \item The \guicmd{Accelerators} tab enables you to select an accelerator package
 for LAMMPS to use.  Only settings supported by the LAMMPS library and local hardware
@@ -4499,7 +4502,7 @@ are available.  The \guicmd{Number of threads} field allows you to set the maxim
 number of threads for accelerator packages that utilize threading.
 \item The \guicmd{Editor Settings} tab allows you to adjust the settings of the editor
 window.  Select the \guicmd{Auto-save on Run and Quit} option to automatically save changes
-made to the \flecmd{.lmp} file upon closing LAMMPS--GUI.
+made to the \flecmd{.lmp} file upon closing \lammpsgui{}.
 \end{itemize}
 See Ref.\,\citenum{lammps_gui_docs} for a full list of options.
 


### PR DESCRIPTION
This pull request restores the intended typesetting of LAMMPS-GUI that was broken through the disabling of ligatures by using a custom \lammpsgui{} macro.

Also, the appendices for installing and running LAMMPS from the command line are corrected and updated.

I am working on adding support for downloading the materials for all 8 tutorials into LAMMPS-GUI before the next feature release and also backport those to the 29Aug2024_update2 release.